### PR TITLE
R79 feature: enforce SSI GraphQL x-api-key usage

### DIFF
--- a/scoring-proxy/lib/ssi-core/client.js
+++ b/scoring-proxy/lib/ssi-core/client.js
@@ -5,15 +5,26 @@ import { log } from '../logger.js'
 // GraphQL client (JWT auth for reads)
 // ============================================================
 
+function resolveGraphQLApiKey(apiKey) {
+  const keyFromArg = typeof apiKey === 'string' ? apiKey.trim() : ''
+  if (keyFromArg) return keyFromArg
+
+  const keyFromEnv = typeof process.env.SSI_ADMIN_API_KEY === 'string'
+    ? process.env.SSI_ADMIN_API_KEY.trim()
+    : ''
+  if (keyFromEnv) return keyFromEnv
+
+  throw new Error('SSI GraphQL API key missing: set SSI_ADMIN_API_KEY')
+}
+
 export async function ssiGraphQL(jwtToken, query, variables = {}, apiKey = null) {
+  const resolvedApiKey = resolveGraphQLApiKey(apiKey)
   const headers = {
     'Content-Type': 'application/json',
+    'x-api-key': resolvedApiKey,
   }
   if (jwtToken) {
     headers['Authorization'] = `JWT ${jwtToken}`
-  }
-  if (apiKey) {
-    headers['X-Api-Key'] = apiKey
   }
 
   const body = JSON.stringify({ query, variables })
@@ -42,7 +53,7 @@ export async function ssiGraphQL(jwtToken, query, variables = {}, apiKey = null)
 // JWT token refresh
 // ============================================================
 
-export async function ssiRefreshJWT(refreshToken) {
+export async function ssiRefreshJWT(refreshToken, apiKey = null) {
   const result = await ssiGraphQL(null, `
     mutation Refresh($refreshToken: String!, $revokeRefreshToken: Boolean!) {
       refresh_token(refresh_token: $refreshToken, revoke_refresh_token: $revokeRefreshToken) {
@@ -50,7 +61,7 @@ export async function ssiRefreshJWT(refreshToken) {
         refresh_token { token }
       }
     }
-  `, { refreshToken, revokeRefreshToken: true })
+  `, { refreshToken, revokeRefreshToken: true }, apiKey)
 
   if (!result.refresh_token?.token?.token) {
     throw new Error('Token refresh failed')

--- a/scoring-proxy/routes/auth-v7.js
+++ b/scoring-proxy/routes/auth-v7.js
@@ -37,6 +37,8 @@ const AUTH_MUTATION = `
   }
 `
 
+const SSI_ADMIN_API_KEY = (process.env.SSI_ADMIN_API_KEY || '').trim()
+
 export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth, graphqlWithRefresh }) {
   const router = express.Router()
 
@@ -44,7 +46,7 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
   // POST /api/auth/login — V7 Login (dual session)
   // ============================================================
   router.post('/login', loginLimiter, async (req, res) => {
-    const { email, password, apiKey, scope } = req.body
+    const { email, password, scope } = req.body
     if (!email || !password) {
       return res.status(400).json({ error: 'email and password required' })
     }
@@ -60,8 +62,14 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
     }
 
     try {
+      const effectiveApiKey = SSI_ADMIN_API_KEY
+      if (!effectiveApiKey) {
+        log.error('[auth-v7] SSI_ADMIN_API_KEY is missing')
+        return res.status(500).json({ error: 'Server configuration error' })
+      }
+
       // 1. Authenticate user — get user's own SSI tokens
-      const authResult = await ssiGraphQL(null, AUTH_MUTATION, { email, password }, apiKey)
+      const authResult = await ssiGraphQL(null, AUTH_MUTATION, { email, password }, effectiveApiKey)
 
       if (!authResult.token_auth?.token?.token) {
         auditLogin(email, req.ip, false, 'Invalid credentials')
@@ -96,7 +104,7 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
           jwt: userJwt,
           refreshToken: userRefreshToken,
           cookies: userCookies,
-          apiKey: apiKey || null,
+          apiKey: effectiveApiKey,
           expiresAt: Date.now() + 15 * 60 * 1000, // SSI JWT ~15 min
         },
         adminSSI,
@@ -286,6 +294,11 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
     }
 
     try {
+      if (!SSI_ADMIN_API_KEY) {
+        log.error('[auth-v7] SSI_ADMIN_API_KEY is missing for token login')
+        return res.status(500).json({ error: 'Server configuration error' })
+      }
+
       const validated = await validateDeviceToken(token)
       if (!validated) {
         log.warn(`[auth-v7] Invalid/expired device token attempt from ${req.ip}`)
@@ -296,7 +309,7 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
       const authResult = await ssiGraphQL(null, AUTH_MUTATION, {
         email: validated.ssiEmail,
         password: validated.ssiPassword,
-      })
+      }, SSI_ADMIN_API_KEY)
 
       if (!authResult.token_auth?.token?.token) {
         log.error(`[auth-v7] Device token SSI auth failed for ${validated.ssiEmail}`)
@@ -330,6 +343,7 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
           jwt: userJwt,
           refreshToken: userRefreshToken,
           cookies: userCookies,
+          apiKey: SSI_ADMIN_API_KEY,
           expiresAt: Date.now() + 15 * 60 * 1000,
         },
         adminSSI,

--- a/scoring-proxy/server.js
+++ b/scoring-proxy/server.js
@@ -26,6 +26,11 @@ const IS_PROD = process.env.NODE_ENV === 'production'
 const IS_RENDER = process.env.RENDER === 'true' // Render platform (production or preview)
 const API_V1_BASE = '/api/v1'
 const API_LEGACY_BASE = '/api'
+const SSI_ADMIN_API_KEY = (process.env.SSI_ADMIN_API_KEY || '').trim()
+
+if (!SSI_ADMIN_API_KEY) {
+  log.warn('[graphql] SSI_ADMIN_API_KEY is not set — GraphQL requests will fail')
+}
 
 function legacyApiAlias(req, res, next) {
   // Temporary backward-compatibility signal for unversioned endpoints.
@@ -145,8 +150,9 @@ function requireAuth(allowedScopes = null) {
 // Works with the legacy-compatible session view from toLegacySession:
 // session.jwt and session.refreshToken are write-through getters/setters.
 async function graphqlWithRefresh(session, query, variables = {}) {
+  const apiKey = session?.apiKey || SSI_ADMIN_API_KEY
   try {
-    return await ssiGraphQL(session.jwt, query, variables)
+    return await ssiGraphQL(session.jwt, query, variables, apiKey)
   } catch (err) {
     // If it looks like a token expiry, try refreshing
     if (session.refreshToken && (
@@ -155,7 +161,7 @@ async function graphqlWithRefresh(session, query, variables = {}) {
       err.message.includes('401')
     )) {
       try {
-        const newTokens = await ssiRefreshJWT(session.refreshToken)
+        const newTokens = await ssiRefreshJWT(session.refreshToken, apiKey)
         session.jwt = newTokens.token
         session.refreshToken = newTokens.refreshToken
         // Persist refreshed tokens back to V7 session store
@@ -169,7 +175,7 @@ async function graphqlWithRefresh(session, query, variables = {}) {
             },
           }).catch(() => {}) // best-effort persistence
         }
-        return await ssiGraphQL(session.jwt, query, variables)
+        return await ssiGraphQL(session.jwt, query, variables, apiKey)
       } catch {
         throw new Error('Session expired. Please login again.')
       }
@@ -211,9 +217,12 @@ const ADMIN_JWT_TTL = 14 * 60 * 1000         // 14 min — SSI JWTs expire ~15 m
 async function getAdminSession() {
   const email = process.env.SSI_ADMIN_EMAIL
   const password = process.env.SSI_ADMIN_PASSWORD
-  const apiKey = process.env.SSI_ADMIN_API_KEY || null
+  const apiKey = SSI_ADMIN_API_KEY || null
   if (!email || !password) {
     throw new Error('Registration not configured: SSI_ADMIN_EMAIL and SSI_ADMIN_PASSWORD required')
+  }
+  if (!apiKey) {
+    throw new Error('Registration not configured: SSI_ADMIN_API_KEY required')
   }
 
   const now = Date.now()
@@ -245,7 +254,7 @@ async function getAdminSession() {
     log.debug('[admin] Refreshing JWT (expired after ~14 min)...')
     try {
       if (adminRefreshToken) {
-        const newTokens = await ssiRefreshJWT(adminRefreshToken)
+        const newTokens = await ssiRefreshJWT(adminRefreshToken, apiKey)
         adminJwt = newTokens.token
         adminRefreshToken = newTokens.refreshToken
         adminJwtTime = now
@@ -291,13 +300,13 @@ async function getAdminSession() {
 async function adminGraphQL(query, variables = {}) {
   const admin = await getAdminSession()
   try {
-    return await ssiGraphQL(admin.jwt, query, variables)
+    return await ssiGraphQL(admin.jwt, query, variables, SSI_ADMIN_API_KEY)
   } catch (err) {
     if (admin.refreshToken && (err.message.includes('expired') || err.message.includes('Signature'))) {
-      const newTokens = await ssiRefreshJWT(admin.refreshToken)
+      const newTokens = await ssiRefreshJWT(admin.refreshToken, SSI_ADMIN_API_KEY)
       adminJwt = newTokens.token
       adminRefreshToken = newTokens.refreshToken
-      return await ssiGraphQL(adminJwt, query, variables)
+      return await ssiGraphQL(adminJwt, query, variables, SSI_ADMIN_API_KEY)
     }
     throw err
   }
@@ -449,7 +458,7 @@ if (isDirectRun) {
     console.log(`Mode: ${IS_PROD ? 'production' : 'development'}`)
     console.log(`Session backend: ${isUsingRedis() ? 'redis' : 'memory'}`)
     console.log('Endpoints:')
-    console.log('  POST /api/v1/auth/login     { email, password, apiKey }')
+    console.log('  POST /api/v1/auth/login     { email, password }')
     console.log('  GET  /api/v1/auth/status')
     console.log('  POST /api/v1/auth/logout')
     console.log('  GET  /api/v1/health')

--- a/scripts-graphql/Get-SSISchema.ps1
+++ b/scripts-graphql/Get-SSISchema.ps1
@@ -5,6 +5,11 @@
 .DESCRIPTION
     Uses GraphQL introspection to discover available queries, mutations, and types
     in the SSI GraphQL API. Outputs the schema to help understand the API structure.
+    API key resolution order: -ApiKey parameter, SSI_ADMIN_API_KEY env var, then config file.
+
+.PARAMETER ApiKey
+    Optional GraphQL API key. If omitted, script uses SSI_ADMIN_API_KEY env var
+    or falls back to the API key config file.
 
 .PARAMETER ApiKeyPath
     Path to the API key configuration file (default: config/api-key.yml)
@@ -17,35 +22,52 @@
 #>
 
 param(
+    [string]$ApiKey,
     [string]$ApiKeyPath,
     [string]$OutputPath = "schema-output.json"
 )
 
-# Import required modules
-Import-Module -Name PowerShell-Yaml -ErrorAction Stop
+$resolvedApiKey = $null
 
-# Load API key configuration
-if (-not $ApiKeyPath) {
-    $ApiKeyPath = Join-Path -Path $PSScriptRoot -ChildPath "config\api-key.yml"
+if ($ApiKey -and $ApiKey -ne "YOUR_API_KEY_HERE") {
+    $resolvedApiKey = $ApiKey.Trim()
 }
 
-if (-not (Test-Path $ApiKeyPath)) {
-    Write-Error "API key configuration file not found: $ApiKeyPath"
-    exit 1
+if (-not $resolvedApiKey -and $env:SSI_ADMIN_API_KEY) {
+    $resolvedApiKey = $env:SSI_ADMIN_API_KEY.Trim()
 }
 
-$apiKeyContent = Get-Content -Path $ApiKeyPath -Raw -Encoding UTF8
-$apiKeyConfig = $apiKeyContent | ConvertFrom-Yaml
+if (-not $resolvedApiKey) {
+    if (-not $ApiKeyPath) {
+        $ApiKeyPath = Join-Path -Path $PSScriptRoot -ChildPath "config\api-key.yml"
+    }
 
-if (-not $apiKeyConfig.apiKey -or $apiKeyConfig.apiKey -eq "YOUR_API_KEY_HERE") {
-    Write-Error "API key not configured. Please set your API key in: $ApiKeyPath"
+    if (-not (Test-Path $ApiKeyPath)) {
+        Write-Error "API key configuration file not found: $ApiKeyPath"
+        exit 1
+    }
+
+    Import-Module -Name PowerShell-Yaml -ErrorAction Stop
+    $apiKeyContent = Get-Content -Path $ApiKeyPath -Raw -Encoding UTF8
+    $apiKeyConfig = $apiKeyContent | ConvertFrom-Yaml
+
+    if (-not $apiKeyConfig.apiKey -or $apiKeyConfig.apiKey -eq "YOUR_API_KEY_HERE") {
+        Write-Error "API key not configured. Set SSI_ADMIN_API_KEY env var or update: $ApiKeyPath"
+        exit 1
+    }
+
+    $resolvedApiKey = $apiKeyConfig.apiKey.Trim()
+}
+
+if (-not $resolvedApiKey) {
+    Write-Error "API key is missing. Set SSI_ADMIN_API_KEY env var or provide -ApiKey/-ApiKeyPath"
     exit 1
 }
 
 $GraphQLEndpoint = "https://shootnscoreit.com/graphql/"
 
 $headers = @{
-    "Authorization" = "Bearer $($apiKeyConfig.apiKey)"
+    "x-api-key" = $resolvedApiKey
     "Content-Type" = "application/json"
     "Accept" = "application/json"
 }

--- a/scripts-graphql/Get-ScoringSchema.ps1
+++ b/scripts-graphql/Get-ScoringSchema.ps1
@@ -3,14 +3,51 @@
     Discovers SSI GraphQL scoring-related schema details
 #>
 
-Import-Module -Name powershell-yaml -ErrorAction Stop
+param(
+    [string]$ApiKey,
+    [string]$ApiKeyPath
+)
 
-$ApiKeyPath = Join-Path -Path $PSScriptRoot -ChildPath "config\api-key.yml"
-$apiKeyConfig = Get-Content -Path $ApiKeyPath -Raw -Encoding UTF8 | ConvertFrom-Yaml
+$resolvedApiKey = $null
+
+if ($ApiKey -and $ApiKey -ne "YOUR_API_KEY_HERE") {
+    $resolvedApiKey = $ApiKey.Trim()
+}
+
+if (-not $resolvedApiKey -and $env:SSI_ADMIN_API_KEY) {
+    $resolvedApiKey = $env:SSI_ADMIN_API_KEY.Trim()
+}
+
+if (-not $resolvedApiKey) {
+    Import-Module -Name powershell-yaml -ErrorAction Stop
+
+    if (-not $ApiKeyPath) {
+        $ApiKeyPath = Join-Path -Path $PSScriptRoot -ChildPath "config\api-key.yml"
+    }
+
+    if (-not (Test-Path $ApiKeyPath)) {
+        Write-Error "API key configuration file not found: $ApiKeyPath"
+        exit 1
+    }
+
+    $apiKeyConfig = Get-Content -Path $ApiKeyPath -Raw -Encoding UTF8 | ConvertFrom-Yaml
+
+    if (-not $apiKeyConfig.apiKey -or $apiKeyConfig.apiKey -eq "YOUR_API_KEY_HERE") {
+        Write-Error "API key not configured. Set SSI_ADMIN_API_KEY env var or update: $ApiKeyPath"
+        exit 1
+    }
+
+    $resolvedApiKey = $apiKeyConfig.apiKey.Trim()
+}
+
+if (-not $resolvedApiKey) {
+    Write-Error "API key is missing. Set SSI_ADMIN_API_KEY env var or provide -ApiKey/-ApiKeyPath"
+    exit 1
+}
 
 $GraphQLEndpoint = "https://shootnscoreit.com/graphql/"
 $headers = @{
-    "Authorization" = "Bearer $($apiKeyConfig.apiKey)"
+    "x-api-key" = $resolvedApiKey
     "Content-Type"  = "application/json"
     "Accept"        = "application/json"
 }


### PR DESCRIPTION
## Summary
- enforce x-api-key on proxy GraphQL requests and fail fast when key is missing
- use SSI_ADMIN_API_KEY as the primary key source in login, token-refresh, admin GraphQL, and token-login flows
- update schema discovery scripts to use x-api-key and resolve key in order: parameter -> env (SSI_ADMIN_API_KEY) -> config fallback
- remove login runtime dependency on request-body piKey

## Validation
- 
ode --check scoring-proxy/lib/ssi-core/client.js
- 
ode --check scoring-proxy/server.js
- 
ode --check scoring-proxy/routes/auth-v7.js
- local smoke flow: POST /api/v1/auth/login -> GET /api/v1/auth/me -> POST /api/v1/auth/logout (all successful)

## Requirement
- advances R7.9 GraphQL exploratory development