### PR TITLE
R79 hotfix: Harden SSI GraphQL upstream failure handling (retry + clean 503)

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -5,6 +5,39 @@
 
 ---
 
+## Release 7.9.1 — GraphQL Upstream Reliability Hotfix (2026-05-08)
+
+**Requirements:** GQL-HF1 ✅, GQL-HF2 ✅, GQL-HF3 ✅
+
+### Overview
+
+Hotfix release focused on production resilience for transient SSI GraphQL outages. The proxy now retries short-lived upstream failures, records actionable diagnostics for incident triage, and returns a clean availability response to UI clients.
+
+### New Features
+
+- **Transient retry with jitter**: `ssiGraphQL` retries transient upstream failures (`HTTP 502/503/504`) and network-style `fetch failed` errors with bounded jittered backoff.
+- **Configurable retry cap**: Retry behavior can be tuned with `SSI_GRAPHQL_MAX_RETRIES` (clamped to 0–2, default 2).
+- **Upstream diagnostics capture**: Retry/final-failure logs include attempt metadata, selected upstream headers, and a response body snippet.
+
+### Bug Fixes
+
+- **Cleaner availability handling**: Transient upstream failures are now mapped to HTTP `503` with user-safe payload (`UPSTREAM_UNAVAILABLE`) instead of surfacing as generic auth/internal failures.
+- **Auth endpoint consistency**: `/api/v1/auth/login` and `/api/v1/auth/token-login` now return consistent `503` responses for transient upstream SSI incidents.
+
+### Requirements Met
+
+- **GQL-HF1:** GraphQL transient retry hardening implemented with jittered backoff.
+- **GQL-HF2:** Upstream diagnostics logging (headers + body snippet) implemented for incident analysis.
+- **GQL-HF3:** UI-facing upstream availability mapping implemented with standardized `503`/`UPSTREAM_UNAVAILABLE` responses.
+
+### Test Status
+
+| Suite | Passing | Notes |
+|-------|--------:|-------|
+| Backend (scoring-proxy) | 215 | Full suite green after hardening + new regression tests |
+
+---
+
 ## Release 7.7 — QR Code Login for Scoring (2026-03-20)
 
 **Requirements:** QR1–QR6 ✅ (all implemented)

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -442,6 +442,14 @@ Migrate Cup creation and maintenance from web scraping to SSI GraphQL API. The l
 - **Config compatibility**: GraphQL scripts must use the same `kupittaa-cup-config.yml` as the legacy scripts. Field name mapping (e.g., `matchCount` → `count`) is handled in the script, not in the config.
 - **WordPress integration**: Calendar event creation (Tapahtumakalenteri) remains web scraping — WordPress REST API requires separate auth. This is out of scope for R7.9.
 
+### Release 7.9.1 — GraphQL Upstream Reliability Hotfix
+
+| # | Fix | Status |
+|---|-----|--------|
+| GQL-HF1 | **Transient upstream retry**: GraphQL requests retry on transient SSI failures (`502/503/504`) and `fetch failed` network errors with jittered backoff (max 2 retries). | ✅ Implemented |
+| GQL-HF2 | **Upstream diagnostics logging**: Failed transient upstream attempts log response header snapshot and body snippet for faster incident triage on Render. | ✅ Implemented |
+| GQL-HF3 | **Clean UI availability error**: Transient upstream incidents are mapped to HTTP `503` with user-safe message/code (`UPSTREAM_UNAVAILABLE`) instead of generic auth/internal failures. | ✅ Implemented |
+
 ## Release 8.1 — Match Management Platform (Roadmap)
 
 Vision: Transform the current "link collection" home page into a structured match management platform. This requires significant UI design and architecture work before implementation.
@@ -481,7 +489,7 @@ Vision: Transform the current "link collection" home page into a structured matc
 - **Release 7.5** (Architecture V2 Foundation): 5 requirements — 3 ✅, 2 📋 ➜ R7.6 (ARCH3, ARCH4)
 - **Release 7.6** (Consolidation & Completion): 18 requirements from R6.0/R7.0/R7.2/R7.5 — see `release-7.6.md`
 - **Release 7.7** (QR Code Login for Scoring): 6 requirements — 6 ✅ (QR1–QR6). Device token auth for tablets/phones at the range. **7.7.1 hotfix**: 4 fixes (cup list visibility, auto-restore, same-day filtering, squad audit logging)
-- **Release 7.9** (GraphQL Cup Management): 6 requirements — 0 ✅, 6 pending (GQL1–GQL6)
+- **Release 7.9** (GraphQL Cup Management): 6 requirements — 0 ✅, 6 pending (GQL1–GQL6). **7.9.1 hotfix**: 3 fixes implemented (GQL-HF1–GQL-HF3)
 - **Release 8.0** (Tablet Scoring UI): 12 requirements — 12 ✅ (TS1–TS12)
 - **Release 8.1** (Match Management Platform): 7 requirements — 0 ✅, 7 design phase (MP1–MP7)
 

--- a/scoring-proxy/lib/ssi-core/client.js
+++ b/scoring-proxy/lib/ssi-core/client.js
@@ -5,6 +5,81 @@ import { log } from '../logger.js'
 // GraphQL client (JWT auth for reads)
 // ============================================================
 
+const RETRYABLE_GRAPHQL_STATUS_CODES = new Set([502, 503, 504])
+const UPSTREAM_UNAVAILABLE_CODE = 'UPSTREAM_UNAVAILABLE'
+const UPSTREAM_UNAVAILABLE_MESSAGE = 'SSI service temporarily unavailable. Please retry.'
+const DEFAULT_GRAPHQL_MAX_RETRIES = 2
+const GRAPHQL_RETRY_BASE_DELAY_MS = 200
+const GRAPHQL_RETRY_JITTER_MS = 150
+const UPSTREAM_BODY_SNIPPET_MAX = 400
+
+function getGraphqlRetryCount() {
+  const value = Number.parseInt(process.env.SSI_GRAPHQL_MAX_RETRIES || `${DEFAULT_GRAPHQL_MAX_RETRIES}`, 10)
+  if (!Number.isFinite(value)) return DEFAULT_GRAPHQL_MAX_RETRIES
+  return Math.max(0, Math.min(DEFAULT_GRAPHQL_MAX_RETRIES, value))
+}
+
+function isRetryableGraphqlStatus(statusCode) {
+  return RETRYABLE_GRAPHQL_STATUS_CODES.has(statusCode)
+}
+
+function isRetryableNetworkError(err) {
+  const message = String(err?.message || '').toLowerCase()
+  return (
+    message.includes('fetch failed')
+    || message.includes('network')
+    || message.includes('econnreset')
+    || message.includes('etimedout')
+    || message.includes('socket hang up')
+  )
+}
+
+function createRetryDelayMs(attempt) {
+  const backoffMs = GRAPHQL_RETRY_BASE_DELAY_MS * attempt
+  const jitterMs = Math.floor(Math.random() * GRAPHQL_RETRY_JITTER_MS)
+  return backoffMs + jitterMs
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function buildUpstreamBodySnippet(rawBody) {
+  if (!rawBody) return ''
+  return String(rawBody).replace(/\s+/g, ' ').trim().slice(0, UPSTREAM_BODY_SNIPPET_MAX)
+}
+
+function extractUpstreamHeaders(headers) {
+  if (!headers?.get) return {}
+
+  const interestingHeaders = [
+    'content-type',
+    'server',
+    'via',
+    'x-request-id',
+    'x-correlation-id',
+    'cf-ray',
+    'date',
+  ]
+
+  const extracted = {}
+  for (const name of interestingHeaders) {
+    const value = headers.get(name)
+    if (value) extracted[name] = value
+  }
+
+  return extracted
+}
+
+function createUpstreamUnavailableError(context = {}) {
+  const err = new Error(UPSTREAM_UNAVAILABLE_MESSAGE)
+  err.code = UPSTREAM_UNAVAILABLE_CODE
+  err.statusCode = 503
+  err.isUpstreamTransient = true
+  Object.assign(err, context)
+  return err
+}
+
 export async function ssiGraphQL(jwtToken, query, variables = {}, apiKey = null) {
   const headers = {
     'Content-Type': 'application/json',
@@ -18,24 +93,102 @@ export async function ssiGraphQL(jwtToken, query, variables = {}, apiKey = null)
 
   const body = JSON.stringify({ query, variables })
 
-  const resp = await fetch(SSI_GRAPHQL, {
-    method: 'POST',
-    headers,
-    body,
-  })
+  const maxRetries = getGraphqlRetryCount()
+  const maxAttempts = maxRetries + 1
 
-  if (!resp.ok) {
-    throw new Error(`GraphQL HTTP ${resp.status}: ${resp.statusText}`)
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let resp
+    try {
+      resp = await fetch(SSI_GRAPHQL, {
+        method: 'POST',
+        headers,
+        body,
+      })
+    } catch (err) {
+      const isRetryable = isRetryableNetworkError(err)
+      const hasRetryLeft = attempt <= maxRetries
+
+      if (isRetryable) {
+        if (hasRetryLeft) {
+          const retryDelayMs = createRetryDelayMs(attempt)
+          log.warn('[ssi-graphql] Network error, retrying request', {
+            attempt,
+            maxAttempts,
+            retryDelayMs,
+            error: err.message,
+          })
+          await delay(retryDelayMs)
+          continue
+        }
+
+        log.warn('[ssi-graphql] Network error, no retries left', {
+          attempt,
+          maxAttempts,
+          error: err.message,
+        })
+        throw createUpstreamUnavailableError({
+          attempts: attempt,
+          upstreamError: err.message,
+        })
+      }
+
+      throw err
+    }
+
+    if (!resp.ok) {
+      const rawBody = await resp.text().catch(() => '')
+      const upstreamBodySnippet = buildUpstreamBodySnippet(rawBody)
+      const upstreamHeaders = extractUpstreamHeaders(resp.headers)
+      const isRetryable = isRetryableGraphqlStatus(resp.status)
+      const hasRetryLeft = attempt <= maxRetries
+
+      if (isRetryable) {
+        if (hasRetryLeft) {
+          const retryDelayMs = createRetryDelayMs(attempt)
+          log.warn('[ssi-graphql] Transient upstream HTTP error, retrying request', {
+            attempt,
+            maxAttempts,
+            retryDelayMs,
+            status: resp.status,
+            statusText: resp.statusText,
+            upstreamHeaders,
+            upstreamBodySnippet,
+          })
+          await delay(retryDelayMs)
+          continue
+        }
+
+        log.warn('[ssi-graphql] Transient upstream HTTP error, no retries left', {
+          attempt,
+          maxAttempts,
+          status: resp.status,
+          statusText: resp.statusText,
+          upstreamHeaders,
+          upstreamBodySnippet,
+        })
+        throw createUpstreamUnavailableError({
+          attempts: attempt,
+          upstreamStatus: resp.status,
+          upstreamStatusText: resp.statusText,
+          upstreamHeaders,
+          upstreamBodySnippet,
+        })
+      }
+
+      throw new Error(`GraphQL HTTP ${resp.status}: ${resp.statusText}`)
+    }
+
+    const json = await resp.json()
+
+    if (json.errors && json.errors.length > 0) {
+      const messages = json.errors.map(e => e.message).join('; ')
+      throw new Error(`GraphQL Error: ${messages}`)
+    }
+
+    return json.data
   }
 
-  const json = await resp.json()
-
-  if (json.errors && json.errors.length > 0) {
-    const messages = json.errors.map(e => e.message).join('; ')
-    throw new Error(`GraphQL Error: ${messages}`)
-  }
-
-  return json.data
+  throw createUpstreamUnavailableError()
 }
 
 // ============================================================

--- a/scoring-proxy/middleware/errorHandler.js
+++ b/scoring-proxy/middleware/errorHandler.js
@@ -15,6 +15,23 @@ import {
   SSIError
 } from '../lib/errors/AppError.js'
 
+const UPSTREAM_UNAVAILABLE_CODE = 'UPSTREAM_UNAVAILABLE'
+const UPSTREAM_UNAVAILABLE_MESSAGE = 'SSI service temporarily unavailable. Please retry.'
+
+/**
+ * Detects transient upstream SSI/GraphQL failures.
+ */
+function isUpstreamUnavailableError(err) {
+  if (!err) return false
+  if (err.code === UPSTREAM_UNAVAILABLE_CODE || err.isUpstreamTransient === true) return true
+
+  const message = String(err.message || '')
+  return (
+    /GraphQL HTTP (502|503|504):/i.test(message)
+    || message.toLowerCase().includes('fetch failed')
+  )
+}
+
 /**
  * Enhances error with request context
  */
@@ -67,8 +84,13 @@ function formatErrorResponse(err) {
     code: 'INTERNAL_ERROR',
     timestamp: new Date().toISOString()
   }
+
+  if (isUpstreamUnavailableError(err)) {
+    response.error = UPSTREAM_UNAVAILABLE_MESSAGE
+    response.code = UPSTREAM_UNAVAILABLE_CODE
+  }
   
-  if (isClientSafeError(err)) {
+  if (!isUpstreamUnavailableError(err) && isClientSafeError(err)) {
     response.error = err.message
     response.code = err.code || 'UNKNOWN_ERROR'
     
@@ -108,12 +130,19 @@ function errorHandler(err, req, res, next) {
   err = enhanceError(err, req)
   
   // Log the error
-  const logLevel = err instanceof AppError && err.isOperational ? 'warn' : 'error'
+  const isUpstreamUnavailable = isUpstreamUnavailableError(err)
+  const logLevel = (err instanceof AppError && err.isOperational) || isUpstreamUnavailable ? 'warn' : 'error'
   
   log[logLevel]('API Error', {
     error: err.message,
     code: err.code,
     statusCode: err.statusCode,
+    upstreamStatus: err.upstreamStatus,
+    upstreamStatusText: err.upstreamStatusText,
+    upstreamHeaders: err.upstreamHeaders,
+    upstreamBodySnippet: err.upstreamBodySnippet,
+    attempts: err.attempts,
+    isUpstreamTransient: err.isUpstreamTransient,
     stack: err.stack,
     path: req.path,
     method: req.method,
@@ -125,7 +154,7 @@ function errorHandler(err, req, res, next) {
   })
   
   // Send response
-  const statusCode = err.statusCode || 500
+  const statusCode = isUpstreamUnavailable ? 503 : (err.statusCode || 500)
   const response = formatErrorResponse(err)
   
   res.status(statusCode).json(response)
@@ -172,6 +201,7 @@ export {
   asyncHandler,
   createError,
   enhanceError,
+  isUpstreamUnavailableError,
   isClientSafeError,
   formatErrorResponse
 }

--- a/scoring-proxy/package-lock.json
+++ b/scoring-proxy/package-lock.json
@@ -516,7 +516,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
       "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1507,7 +1506,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1569,7 +1567,6 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -2148,7 +2145,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2257,7 +2253,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
       "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.10.0",
         "@redis/client": "5.10.0",
@@ -2712,7 +2707,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2888,7 +2882,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/scoring-proxy/routes/auth-v7.js
+++ b/scoring-proxy/routes/auth-v7.js
@@ -21,6 +21,20 @@ import {
   auditLogout,
 } from '../lib/session/index.js'
 
+const UPSTREAM_UNAVAILABLE_CODE = 'UPSTREAM_UNAVAILABLE'
+const UPSTREAM_UNAVAILABLE_MESSAGE = 'SSI service temporarily unavailable. Please retry.'
+
+function isUpstreamUnavailableError(err) {
+  if (!err) return false
+  if (err.code === UPSTREAM_UNAVAILABLE_CODE || err.isUpstreamTransient === true) return true
+
+  const message = String(err.message || '')
+  return (
+    /GraphQL HTTP (502|503|504):/i.test(message)
+    || message.toLowerCase().includes('fetch failed')
+  )
+}
+
 function internalError(message) {
   return new AppError(message, 500, 'INTERNAL_ERROR')
 }
@@ -132,6 +146,19 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
         scope: sessionScope,
       })
     } catch (err) {
+      if (isUpstreamUnavailableError(err)) {
+        auditLogin(email, req.ip, false, UPSTREAM_UNAVAILABLE_CODE)
+        log.warn('[auth-v7] Login failed due upstream availability issue:', {
+          error: err.message,
+          upstreamStatus: err.upstreamStatus,
+          attempts: err.attempts,
+        })
+        return res.status(503).json({
+          error: UPSTREAM_UNAVAILABLE_MESSAGE,
+          code: UPSTREAM_UNAVAILABLE_CODE,
+        })
+      }
+
       auditLogin(email, req.ip, false, err.message)
       log.error('[auth-v7] Login failed:', err.message)
       res.status(401).json({ error: 'Login failed' })
@@ -360,6 +387,18 @@ export function createAuthV7Router({ loginLimiter, getAdminSession, requireAuth,
         label: validated.label,
       })
     } catch (err) {
+      if (isUpstreamUnavailableError(err)) {
+        log.warn('[auth-v7] Token login failed due upstream availability issue:', {
+          error: err.message,
+          upstreamStatus: err.upstreamStatus,
+          attempts: err.attempts,
+        })
+        return res.status(503).json({
+          error: UPSTREAM_UNAVAILABLE_MESSAGE,
+          code: UPSTREAM_UNAVAILABLE_CODE,
+        })
+      }
+
       log.error('[auth-v7] Token login failed:', err.message)
       // Distinguish auth failures from internal errors
       const status = err.message?.includes('credentials') || err.message?.includes('auth') ? 401 : 500

--- a/scoring-proxy/test/error-handler.test.js
+++ b/scoring-proxy/test/error-handler.test.js
@@ -107,6 +107,19 @@ describe('Error Handling Middleware', () => {
       expect(response.body.ssiStatusCode).toBe(504)
     })
 
+    it('maps transient GraphQL upstream failures to 503 with a clean UI message', async () => {
+      app.get('/test', (req, res, next) => {
+        next(new Error('GraphQL HTTP 502: Bad Gateway'))
+      })
+      app.use(errorHandler)
+
+      const response = await request(app).get('/test')
+
+      expect(response.status).toBe(503)
+      expect(response.body.error).toBe('SSI service temporarily unavailable. Please retry.')
+      expect(response.body.code).toBe('UPSTREAM_UNAVAILABLE')
+    })
+
     it('hides generic error details from client', async () => {
       app.get('/test', (req, res, next) => {
         next(new Error('Unexpected internal bug'))
@@ -266,6 +279,14 @@ describe('Error Handling Middleware', () => {
 
       expect(response.error).toBe('Internal server error')
       expect(response.code).toBe('INTERNAL_ERROR')
+    })
+
+    it('formats upstream unavailable errors with a user-safe response', () => {
+      const err = new Error('fetch failed')
+      const response = formatErrorResponse(err)
+
+      expect(response.error).toBe('SSI service temporarily unavailable. Please retry.')
+      expect(response.code).toBe('UPSTREAM_UNAVAILABLE')
     })
 
     it('includes requestId when present on error', () => {

--- a/scoring-proxy/test/ssi-core-client.test.js
+++ b/scoring-proxy/test/ssi-core-client.test.js
@@ -7,6 +7,7 @@ import { ssiFindCompetitorInMatch, ssiGraphQL } from '../lib/ssi-core/client.js'
 
 afterEach(() => {
   delete process.env.SSI_GRAPHQL_MAX_RETRIES
+  delete process.env.SSI_ADMIN_API_KEY
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -20,6 +21,7 @@ function makeHeaders(values = {}) {
 describe('ssiGraphQL hardening', () => {
   it('retries once on transient 502 and succeeds', async () => {
     process.env.SSI_GRAPHQL_MAX_RETRIES = '2'
+    process.env.SSI_ADMIN_API_KEY = 'test-api-key'
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
@@ -44,6 +46,7 @@ describe('ssiGraphQL hardening', () => {
 
   it('maps fetch-failed upstream errors to UPSTREAM_UNAVAILABLE', async () => {
     process.env.SSI_GRAPHQL_MAX_RETRIES = '0'
+    process.env.SSI_ADMIN_API_KEY = 'test-api-key'
 
     const fetchMock = vi.fn().mockRejectedValue(new Error('fetch failed'))
     vi.stubGlobal('fetch', fetchMock)

--- a/scoring-proxy/test/ssi-core-client.test.js
+++ b/scoring-proxy/test/ssi-core-client.test.js
@@ -3,11 +3,58 @@
 // ============================================================
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { ssiFindCompetitorInMatch } from '../lib/ssi-core/client.js'
+import { ssiFindCompetitorInMatch, ssiGraphQL } from '../lib/ssi-core/client.js'
 
 afterEach(() => {
+  delete process.env.SSI_GRAPHQL_MAX_RETRIES
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+})
+
+function makeHeaders(values = {}) {
+  return {
+    get: (name) => values[name.toLowerCase()] || null,
+  }
+}
+
+describe('ssiGraphQL hardening', () => {
+  it('retries once on transient 502 and succeeds', async () => {
+    process.env.SSI_GRAPHQL_MAX_RETRIES = '2'
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        text: async () => '<html>bad gateway</html>',
+        headers: makeHeaders({ 'content-type': 'text/html' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { ok: true } }),
+      })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const data = await ssiGraphQL('jwt-token', 'query { ok }')
+
+    expect(data).toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('maps fetch-failed upstream errors to UPSTREAM_UNAVAILABLE', async () => {
+    process.env.SSI_GRAPHQL_MAX_RETRIES = '0'
+
+    const fetchMock = vi.fn().mockRejectedValue(new Error('fetch failed'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ssiGraphQL('jwt-token', 'query { ok }')).rejects.toMatchObject({
+      code: 'UPSTREAM_UNAVAILABLE',
+      statusCode: 503,
+      isUpstreamTransient: true,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('ssiFindCompetitorInMatch', () => {


### PR DESCRIPTION
## Summary
- Harden SSI GraphQL calls against transient upstream failures.
- Retry transient failures (502/503/504 and network etch failed) with bounded jittered backoff.
- Add actionable upstream diagnostics (selected headers + response body snippet) for incident triage.
- Map transient upstream failures to clean UI-facing 503 responses with UPSTREAM_UNAVAILABLE.

## Why
Production incidents showed intermittent SSI upstream/gateway failures causing noisy auth/internal errors and poor UX. This hotfix makes failures safer and easier to diagnose.

## Changes
- scoring-proxy/lib/ssi-core/client.js
  - Added transient retry logic with jitter.
  - Added configurable retry cap via SSI_GRAPHQL_MAX_RETRIES (clamped 0-2, default 2).
  - Added upstream diagnostics capture and structured upstream-unavailable error context.
- scoring-proxy/middleware/errorHandler.js
  - Added transient-upstream detection and standardized 503 response mapping.
  - Included upstream diagnostics fields in API error logs.
- scoring-proxy/routes/auth-v7.js
  - /auth/login and /auth/token-login now return consistent 503 + UPSTREAM_UNAVAILABLE when SSI transiently fails.
- Tests
  - scoring-proxy/test/ssi-core-client.test.js
  - scoring-proxy/test/error-handler.test.js
- Docs (kept in sync)
  - docs/requirements/requirements.md (Release 7.9.1 hotfix entries GQL-HF1..3)
  - docs/RELEASE-NOTES.md (new Release 7.9.1 section)

## Requirements
- Release 7.9.1 hotfix requirements implemented:
  - GQL-HF1 retry/jitter hardening
  - GQL-HF2 upstream diagnostics logging
  - GQL-HF3 clean 503 UI mapping

## Validation
- 
pm test -- test/error-handler.test.js test/ssi-core-client.test.js
- 
pm test (full backend suite)

All backend tests passing (215).