### PR TITLE
R79 hotfix: restore cup competitor counts in register/manage

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -38,6 +38,38 @@ Hotfix release focused on production resilience for transient SSI GraphQL outage
 
 ---
 
+## Release 7.9.2 — Cup Competitor Count Hotfix (2026-05-08)
+
+**Requirements:** GQL-HF4 ✅
+
+### Overview
+
+Hotfix release focused on restoring accurate cup competitor counts across registration and management UIs. Count badges now use CUP-level approved competitor data and no longer collapse to `0/max` when squad competitor payloads are sparse.
+
+### New Features
+
+- **CUP-level count source**: Registered competitor totals now prefer CUP-level competitor collection (`event.competitors`) with approved-status filtering (`a` / `approved`).
+- **Fallback compatibility path**: Match-squad competitor counting remains as fallback to preserve behavior when CUP-level list is unavailable.
+- **UI count mapping hardening**: Shared cup list rendering now accepts alternate count field names and numeric-string payloads, keeping badges visible across views.
+
+### Bug Fixes
+
+- **Missing/zero competitor badges fixed**: Registration and management cup lists no longer rely solely on first-match squads, which could be empty and produce false zero counts.
+- **Count consistency across endpoints**: `/api/register/cups`, `/api/register/cup/:id`, and `/api/manage/cups` now use aligned counting rules.
+
+### Requirements Met
+
+- **GQL-HF4:** Cup competitor count source hardened to CUP-level approved competitors with fallback path, restoring accurate UI count display.
+
+### Test Status
+
+| Suite | Passing | Notes |
+|-------|--------:|-------|
+| Backend (scoring-proxy) | 60 | Targeted suites green: `cup-manage`, `management`, `registration` |
+| Frontend (scoring-ui) | 27 | `components.test.jsx` green including new `CupList` count regression |
+
+---
+
 ## Release 7.7 — QR Code Login for Scoring (2026-03-20)
 
 **Requirements:** QR1–QR6 ✅ (all implemented)

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -450,6 +450,12 @@ Migrate Cup creation and maintenance from web scraping to SSI GraphQL API. The l
 | GQL-HF2 | **Upstream diagnostics logging**: Failed transient upstream attempts log response header snapshot and body snippet for faster incident triage on Render. | ✅ Implemented |
 | GQL-HF3 | **Clean UI availability error**: Transient upstream incidents are mapped to HTTP `503` with user-safe message/code (`UPSTREAM_UNAVAILABLE`) instead of generic auth/internal failures. | ✅ Implemented |
 
+### Release 7.9.2 — Cup Competitor Count Hotfix
+
+| # | Fix | Status |
+|---|-----|--------|
+| GQL-HF4 | **Cup competitor count source hardening**: Cup registered competitor totals are calculated from CUP-level approved competitors first (`status` = `a/approved`) with match-squad fallback, so registration and management UI views keep accurate count badges even when squad competitor data is incomplete. | ✅ Implemented |
+
 ## Release 8.1 — Match Management Platform (Roadmap)
 
 Vision: Transform the current "link collection" home page into a structured match management platform. This requires significant UI design and architecture work before implementation.
@@ -489,7 +495,7 @@ Vision: Transform the current "link collection" home page into a structured matc
 - **Release 7.5** (Architecture V2 Foundation): 5 requirements — 3 ✅, 2 📋 ➜ R7.6 (ARCH3, ARCH4)
 - **Release 7.6** (Consolidation & Completion): 18 requirements from R6.0/R7.0/R7.2/R7.5 — see `release-7.6.md`
 - **Release 7.7** (QR Code Login for Scoring): 6 requirements — 6 ✅ (QR1–QR6). Device token auth for tablets/phones at the range. **7.7.1 hotfix**: 4 fixes (cup list visibility, auto-restore, same-day filtering, squad audit logging)
-- **Release 7.9** (GraphQL Cup Management): 6 requirements — 0 ✅, 6 pending (GQL1–GQL6). **7.9.1 hotfix**: 3 fixes implemented (GQL-HF1–GQL-HF3)
+- **Release 7.9** (GraphQL Cup Management): 6 requirements — 0 ✅, 6 pending (GQL1–GQL6). **7.9.1 hotfix**: 3 fixes implemented (GQL-HF1–GQL-HF3). **7.9.2 hotfix**: 1 fix implemented (GQL-HF4)
 - **Release 8.0** (Tablet Scoring UI): 12 requirements — 12 ✅ (TS1–TS12)
 - **Release 8.1** (Match Management Platform): 7 requirements — 0 ✅, 7 design phase (MP1–MP7)
 

--- a/scoring-proxy/lib/services/cup-manage.js
+++ b/scoring-proxy/lib/services/cup-manage.js
@@ -313,16 +313,7 @@ export function filterManageableCups(events, now = new Date()) {
       return effectiveEnd > now
     })
     .map(c => {
-      const firstMatch = (c.component_matches || []).find(cm => cm.included && cm.match)
-      const approvedIds = new Set()
-      if (firstMatch?.match?.squads) {
-        for (const s of firstMatch.match.squads) {
-          for (const comp of (s.competitors || [])) {
-            if (comp.status === 'a') approvedIds.add(comp.id)
-          }
-        }
-      }
-      const registered = approvedIds.size
+      const registered = countRegisteredCupCompetitors(c)
       const maxCompetitors = c.max_competitors || 25
       const full = registered >= maxCompetitors
       const regStarts = c.registration_starts ? new Date(c.registration_starts) : null
@@ -383,6 +374,44 @@ function mapCupCompetitor(c) {
     hasEmailError: !email,
     name: `${firstName} ${lastName}`.trim(),
   }
+}
+
+function countRegisteredCupCompetitors(cupEvent) {
+  const fromCup = countApprovedCupCompetitors(cupEvent?.competitors)
+  if (fromCup > 0) return fromCup
+  return countApprovedMatchSquadCompetitors(cupEvent?.component_matches)
+}
+
+function countApprovedCupCompetitors(competitors = []) {
+  const approvedIds = new Set()
+  for (const competitor of competitors || []) {
+    if (isApprovedStatus(competitor?.status) && competitor?.id != null) {
+      approvedIds.add(String(competitor.id))
+    }
+  }
+  return approvedIds.size
+}
+
+function countApprovedMatchSquadCompetitors(componentMatches = []) {
+  const firstMatch = (componentMatches || []).find(cm => cm.included && cm.match)
+  const approvedIds = new Set()
+
+  if (firstMatch?.match?.squads) {
+    for (const squad of firstMatch.match.squads) {
+      for (const competitor of (squad.competitors || [])) {
+        if (isApprovedStatus(competitor?.status) && competitor?.id != null) {
+          approvedIds.add(String(competitor.id))
+        }
+      }
+    }
+  }
+
+  return approvedIds.size
+}
+
+function isApprovedStatus(status) {
+  const normalized = String(status || '').toLowerCase()
+  return normalized === 'a' || normalized === 'approved'
 }
 
 // Key for unique shooter identification by (firstName, lastName, email) triplet

--- a/scoring-proxy/routes/management.js
+++ b/scoring-proxy/routes/management.js
@@ -42,6 +42,7 @@ export function createManagementRouter({ requireAuth, graphqlWithRefresh, adminG
             max_competitors
             registration
             ... on NordicSerieNode {
+              competitors { id status }
               registration_starts
               registration_closes
               component_matches {

--- a/scoring-proxy/routes/registration.js
+++ b/scoring-proxy/routes/registration.js
@@ -15,6 +15,44 @@ function internalError(message) {
   return new AppError(message, 500, 'INTERNAL_ERROR')
 }
 
+function isApprovedStatus(status) {
+  const normalized = String(status || '').toLowerCase()
+  return normalized === 'a' || normalized === 'approved'
+}
+
+function countApprovedCupCompetitors(competitors = []) {
+  const approvedIds = new Set()
+  for (const competitor of competitors || []) {
+    if (isApprovedStatus(competitor?.status) && competitor?.id != null) {
+      approvedIds.add(String(competitor.id))
+    }
+  }
+  return approvedIds.size
+}
+
+function countApprovedSquadCompetitors(componentMatches = []) {
+  const firstMatch = (componentMatches || []).find(cm => cm.included && cm.match)
+  const approvedIds = new Set()
+
+  if (firstMatch?.match?.squads) {
+    for (const squad of firstMatch.match.squads) {
+      for (const competitor of (squad.competitors || [])) {
+        if (isApprovedStatus(competitor?.status) && competitor?.id != null) {
+          approvedIds.add(String(competitor.id))
+        }
+      }
+    }
+  }
+
+  return approvedIds.size
+}
+
+function countRegisteredCupCompetitors(cupEvent) {
+  const fromCup = countApprovedCupCompetitors(cupEvent?.competitors)
+  if (fromCup > 0) return fromCup
+  return countApprovedSquadCompetitors(cupEvent?.component_matches)
+}
+
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const MAX_EMAIL_LEN = 254
@@ -119,6 +157,7 @@ export function createRegistrationRouter({
             max_competitors
             registration
             ... on NordicSerieNode {
+              competitors { id status }
               registration_starts
               registration_closes
               component_matches {
@@ -142,18 +181,7 @@ export function createRegistrationRouter({
         .filter(e => new Date(e.starts) > now) // future only
         .filter(e => e.status === 'on')         // active only
         .map(c => {
-          // Count approved competitors from the first component match's squads
-          // (all matches have the same competitors, so first match is representative)
-          const firstMatch = (c.component_matches || []).find(cm => cm.included && cm.match)
-          const approvedIds = new Set()
-          if (firstMatch?.match?.squads) {
-            for (const s of firstMatch.match.squads) {
-              for (const comp of (s.competitors || [])) {
-                if (comp.status === 'a') approvedIds.add(comp.id)
-              }
-            }
-          }
-          const registered = approvedIds.size
+          const registered = countRegisteredCupCompetitors(c)
           const maxCompetitors = c.max_competitors || 25
           const full = registered >= maxCompetitors
           const regStarts = c.registration_starts ? new Date(c.registration_starts) : null
@@ -199,6 +227,7 @@ export function createRegistrationRouter({
             id name starts status
             max_competitors
             ... on NordicSerieNode {
+              competitors { id status }
               component_matches {
                 number included
                 match {
@@ -255,13 +284,7 @@ export function createRegistrationRouter({
         }
       })
 
-      // Count approved competitors from first match's squads (same as cups list endpoint)
-      const approvedIds = new Set()
-      for (const sq of (firstMatch.squads || [])) {
-        for (const comp of (sq.competitors || [])) {
-          if (comp.status === 'a') approvedIds.add(comp.id)
-        }
-      }
+      const registered = countRegisteredCupCompetitors(cup)
 
       res.json({
         id: cup.id,
@@ -269,7 +292,7 @@ export function createRegistrationRouter({
         starts: cup.starts,
         status: cup.status,
         maxCompetitors: cup.max_competitors || 25,
-        registered: approvedIds.size,
+        registered,
         squads,
       })
     } catch (err) {

--- a/scoring-proxy/test/cup-manage.test.js
+++ b/scoring-proxy/test/cup-manage.test.js
@@ -110,6 +110,31 @@ describe('filterManageableCups', () => {
     expect(cups[0].registrationOpen).toBe(false)
   })
 
+  it('prefers cup-level competitors when squad competitor data is missing', () => {
+    const cupWithCupCompetitorsOnly = {
+      ...baseCup,
+      max_competitors: 5,
+      competitors: [
+        { id: 'cp1', status: 'a' },
+        { id: 'cp2', status: 'a' },
+        { id: 'cp3', status: 'p' },
+      ],
+      component_matches: [{
+        included: true,
+        match: {
+          squads: [],
+        },
+      }],
+    }
+
+    const now = new Date('2026-02-15T12:00:00Z')
+    const cups = filterManageableCups([cupWithCupCompetitorsOnly], now)
+
+    expect(cups).toHaveLength(1)
+    expect(cups[0].registered).toBe(2)
+    expect(cups[0].full).toBe(false)
+  })
+
   it('sorts cups by start date', () => {
     const cup1 = { ...baseCup, id: '1', starts: '2026-03-10T10:00:00Z', ends: '2026-03-10T18:00:00Z' }
     const cup2 = { ...baseCup, id: '2', starts: '2026-03-05T10:00:00Z', ends: '2026-03-05T18:00:00Z' }

--- a/scoring-proxy/test/management.test.js
+++ b/scoring-proxy/test/management.test.js
@@ -590,6 +590,47 @@ describe('GET /api/manage/cups', () => {
     expect(res.data.cups[0].full).toBe(false) // 1 < 5
     expect(res.data.cups[0].registrationOpen).toBe(true) // open and has space
   })
+
+  it('uses cup-level competitors for count when squads are empty', async () => {
+    const ip = uniqueIp()
+    const { sessionId } = await createSession(createMockSessionInput({ scope: 'manage' }))
+
+    app.setMockResponse({
+      events: [
+        {
+          id: '703',
+          name: 'Cup Competitor Count Fallback',
+          starts: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+          ends: new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+          status: 'on',
+          get_content_type_key: 136,
+          max_competitors: 5,
+          registration: 'op',
+          registration_starts: new Date(Date.now() - 1000).toISOString(),
+          registration_closes: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000).toISOString(),
+          competitors: [
+            { id: 'cp1', status: 'a' },
+            { id: 'cp2', status: 'a' },
+            { id: 'cp3', status: 'p' },
+          ],
+          component_matches: [{
+            number: 1,
+            included: true,
+            match: {
+              squads: [],
+            },
+          }],
+        },
+      ],
+    })
+
+    const res = await request('GET', '/api/manage/cups', null, ip, { ssi_session: sessionId })
+
+    expect(res.status).toBe(200)
+    expect(res.data.cups.length).toBe(1)
+    expect(res.data.cups[0].registered).toBe(2)
+    expect(res.data.cups[0].maxCompetitors).toBe(5)
+  })
 })
 
 // ============================================================

--- a/scoring-ui/src/components/shared.jsx
+++ b/scoring-ui/src/components/shared.jsx
@@ -38,6 +38,30 @@ export function isFuture(isoDate) {
   return parseDateLocal(isoDate) > new Date()
 }
 
+function toFiniteNumber(value, fallback = 0) {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
+function getCupRegisteredCount(cup) {
+  return toFiniteNumber(
+    cup?.registered
+    ?? cup?.registeredCompetitors
+    ?? cup?.competitorCount
+    ?? cup?.currentCompetitors,
+    0
+  )
+}
+
+function getCupMaxCompetitors(cup) {
+  return toFiniteNumber(
+    cup?.maxCompetitors
+    ?? cup?.max_competitors
+    ?? cup?.competitorLimit,
+    25
+  )
+}
+
 export function BackButton({ label, onClick }) {
   return (
     <button
@@ -119,6 +143,8 @@ export function CupList({ cups, onSelect, loading, openLabel = 'Ilmoittautuminen
           </h2>
           {openCups.map(cup => {
             const cupIsToday = isToday(cup.starts)
+            const registeredCount = getCupRegisteredCount(cup)
+            const maxCompetitors = getCupMaxCompetitors(cup)
             return (
               <button
                 key={cup.id}
@@ -145,7 +171,7 @@ export function CupList({ cups, onSelect, loading, openLabel = 'Ilmoittautuminen
                   <div className="text-xs text-gray-400 mt-0.5">{formatDateShort(cup.starts)}</div>
                 </div>
                 <span className="inline-block px-2 py-1 rounded-lg text-xs font-medium shrink-0 bg-green-100 text-green-700">
-                  {cup.registered}/{cup.maxCompetitors}
+                  {registeredCount}/{maxCompetitors}
                 </span>
                 <div className="text-gray-300 shrink-0">
                   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/scoring-ui/src/test/components.test.jsx
+++ b/scoring-ui/src/test/components.test.jsx
@@ -6,6 +6,7 @@ import MatchPicker from '../components/MatchPicker'
 import SquadPicker from '../components/SquadPicker'
 import ShooterPicker from '../components/ShooterPicker'
 import CupSearch from '../components/CupSearch'
+import { CupList } from '../components/shared'
 
 // ============================================================
 // LoginScreen
@@ -97,6 +98,27 @@ describe('CupSearch', () => {
     render(<CupSearch onSelectCup={vi.fn()} loading={false} onLogout={onLogout} />)
     await userEvent.click(screen.getByText('Kirjaudu ulos'))
     expect(onLogout).toHaveBeenCalled()
+  })
+})
+
+// ============================================================
+// CupList
+// ============================================================
+
+describe('CupList', () => {
+  it('renders competitor count using fallback field names', () => {
+    const cups = [{
+      id: 'cup-1',
+      name: 'Fallback Count Cup',
+      starts: '2026-02-21T10:00:00Z',
+      registrationOpen: true,
+      competitorCount: '7',
+      max_competitors: '30',
+    }]
+
+    render(<CupList cups={cups} onSelect={vi.fn()} loading={false} />)
+
+    expect(screen.getByText('7/30')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
Fixes competitor count regression by preferring CUP-level approved competitors with squad fallback, aligns manage/register endpoints, adds backend+frontend regression tests, and updates Release 7.9.2 docs (GQL-HF4).