### PR TITLE
R81: Specify public registration buffer design

### DIFF
--- a/docs/design/registration-buffer-design.md
+++ b/docs/design/registration-buffer-design.md
@@ -1,0 +1,643 @@
+# Registration Buffer Design
+
+**Release:** 8.1 — Public Registration Buffer  
+**Status:** Draft design  
+**Branch:** `R81-feature-registration-buffer-design`  
+**Product variant:** Current `main` TurRes SSI tools product, not the R80 platform product.
+
+---
+
+## 1. Problem Statement
+
+The current `#/register` flow is optimized for shooters who already have an SSI account. It asks for an SSI email, then the backend immediately tries to:
+
+1. add the shooter to the Cup,
+2. approve the Cup participant,
+3. add the shooter to each component match,
+4. assign the selected squad in each match,
+5. send a confirmation email.
+
+If SSI cannot find the email, the public registration fails from the user's point of view. Operationally this is wrong for Kupittaa Cup because some valid participants do not have SSI accounts. The organizer still needs a reliable total attendance list and squad grouping.
+
+The design change is:
+
+> The TurRes app owns the public registration list. SSI synchronization is a best-effort downstream process.
+
+---
+
+## 2. Current Flow
+
+```text
+WordPress/Tapahtumakalenteri event page
+  -> #/register
+  -> captcha
+  -> Cup selection
+  -> squad selection
+  -> SSI email
+  -> immediate SSI Cup + match + squad operation
+  -> success OR user_not_found failure
+```
+
+Problems:
+
+- Total attendance is fragmented between SSI and informal/manual registrations.
+- Non-SSI participants are not captured in the system.
+- Capacity cannot be trusted if it only reads SSI competitors.
+- If SSI is temporarily unavailable, a valid registration can fail.
+- The organizer lacks a fallback list for range-day operations.
+
+---
+
+## 3. Target Flow
+
+```text
+WordPress/Tapahtumakalenteri event page
+  -> #/register?cup=150&squad=1  (optional preselection)
+  -> captcha
+  -> Cup + squad selection
+  -> contact + SSI-account answer
+  -> persist local registration in PostgreSQL
+  -> best-effort SSI sync if possible
+  -> user receives confirmation either way
+```
+
+Organizer flow:
+
+```text
+Authenticated organizer view
+  -> select Cup
+  -> see all local active registrations grouped by squad
+  -> see SSI sync state per registration
+  -> export CSV
+  -> retry sync or mark manually handled/cancelled
+```
+
+---
+
+## 4. Product Boundary
+
+This repository currently contains at least two product directions in branches:
+
+- `main`: current TurRes SSI tools: scoring, registration, management, reports.
+- R80 branch/release line: broader match-management/platform product using PostgreSQL and tenant/account concepts.
+
+This design is for the `main` product only. R80 may be used as a reference for PostgreSQL patterns, especially:
+
+- `DATABASE_URL`-controlled database enablement,
+- optional PostgreSQL feature availability when no database is configured,
+- idempotent schema initialization,
+- `DB_SCHEMA`-style preview isolation,
+- parameterized `query()` and `withTransaction()` helpers.
+
+The R80 tenant/account/platform model must not be merged into this feature unless explicitly approved.
+
+---
+
+## 5. Data Model
+
+The MVP needs a small product-specific schema. Table names are prefixed with `public_registration_` to avoid collision with future platform tables.
+
+### 5.1 `public_registration_events`
+
+Optional local cache of public event metadata. This table is not the source of SSI event truth, but it provides stable local references and denormalized display fields.
+
+```sql
+CREATE TABLE IF NOT EXISTS public_registration_events (
+  id                 TEXT PRIMARY KEY,
+  ssi_cup_id          TEXT NOT NULL UNIQUE,
+  cup_name            TEXT NOT NULL,
+  starts_at           TIMESTAMPTZ,
+  max_competitors     INT,
+  metadata            JSONB DEFAULT '{}',
+  created_at          TIMESTAMPTZ DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+MVP option: skip this table and store Cup snapshot directly on each registration. The table becomes useful once organizer views and historical reporting are added.
+
+### 5.2 `public_registrations`
+
+Authoritative local registration row.
+
+```sql
+CREATE TABLE IF NOT EXISTS public_registrations (
+  id                    TEXT PRIMARY KEY,
+  ssi_cup_id             TEXT NOT NULL,
+  cup_name_snapshot      TEXT NOT NULL,
+  cup_starts_snapshot    TIMESTAMPTZ,
+
+  selected_squad_number  INT NOT NULL,
+  selected_squad_label   TEXT,
+
+  shooter_name           TEXT,
+  email                  TEXT,
+  phone                  TEXT,
+  has_ssi_account        TEXT NOT NULL, -- yes, no, unsure
+  ssi_email              TEXT,
+
+  status                 TEXT NOT NULL DEFAULT 'confirmed',
+  sync_status            TEXT NOT NULL DEFAULT 'pending',
+  sync_error_code        TEXT,
+  sync_error_message     TEXT,
+  last_sync_attempt_at   TIMESTAMPTZ,
+  synced_at              TIMESTAMPTZ,
+
+  created_at             TIMESTAMPTZ DEFAULT NOW(),
+  updated_at             TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+Suggested status values:
+
+| Status | Meaning |
+|--------|---------|
+| `confirmed` | Active registration counted in capacity. |
+| `waitlisted` | Captured but not counted as confirmed participant unless explicitly configured. |
+| `cancelled` | Not active and not counted. |
+| `manual_handled` | Organizer handled outside automated sync. Still active unless cancelled. |
+
+Suggested sync status values:
+
+| Sync status | Meaning |
+|-------------|---------|
+| `not_applicable` | Shooter has no SSI account or organizer chose local-only handling. |
+| `pending` | Should be synchronized to SSI. |
+| `syncing` | Sync attempt in progress; useful for scheduled workers. |
+| `synced` | Cup and component match squadding completed. |
+| `partial` | Some SSI operations succeeded, others failed. |
+| `failed` | Sync attempted but failed. |
+| `manual_needed` | Requires organizer action, e.g. ambiguous identity or missing SSI account. |
+
+Indexes and uniqueness:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_public_registrations_cup
+  ON public_registrations (ssi_cup_id);
+
+CREATE INDEX IF NOT EXISTS idx_public_registrations_cup_squad
+  ON public_registrations (ssi_cup_id, selected_squad_number);
+
+CREATE INDEX IF NOT EXISTS idx_public_registrations_sync
+  ON public_registrations (sync_status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_public_registrations_unique_active_email
+  ON public_registrations (ssi_cup_id, LOWER(COALESCE(email, ssi_email)))
+  WHERE status != 'cancelled' AND COALESCE(email, ssi_email) IS NOT NULL;
+```
+
+Open point: if the no-SSI flow allows no email, a second uniqueness rule is needed. Recommendation: require email for all public registrations and make phone optional. This keeps updates and duplicate prevention practical.
+
+### 5.3 `public_registration_sync_attempts`
+
+Append-only troubleshooting/audit log for SSI sync.
+
+```sql
+CREATE TABLE IF NOT EXISTS public_registration_sync_attempts (
+  id                TEXT PRIMARY KEY,
+  registration_id   TEXT NOT NULL REFERENCES public_registrations(id) ON DELETE CASCADE,
+  attempt_number    INT NOT NULL,
+  trigger           TEXT NOT NULL, -- submit, manual_retry, scheduled
+  status            TEXT NOT NULL, -- success, partial, failed
+  started_at        TIMESTAMPTZ DEFAULT NOW(),
+  finished_at       TIMESTAMPTZ,
+  error_code        TEXT,
+  error_message     TEXT,
+  details           JSONB DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_public_registration_sync_attempts_registration
+  ON public_registration_sync_attempts (registration_id);
+```
+
+Public responses must not include `details`; it is organizer/debug data.
+
+---
+
+## 6. API Design
+
+All new endpoints use `/api/v1/`.
+
+### 6.1 Public submit
+
+Existing endpoint can be evolved:
+
+```text
+POST /api/v1/register/submit
+```
+
+Current body:
+
+```json
+{
+  "cupId": "150",
+  "squadNumber": 1,
+  "email": "person@example.com",
+  "captchaId": "...",
+  "captchaAnswer": 42
+}
+```
+
+Target body:
+
+```json
+{
+  "cupId": "150",
+  "squadNumber": 1,
+  "name": "Matti Meikäläinen",
+  "email": "person@example.com",
+  "phone": "optional",
+  "hasSsiAccount": "yes",
+  "ssiEmail": "person@example.com",
+  "captchaId": "...",
+  "captchaAnswer": 42
+}
+```
+
+Validation:
+
+- `cupId`: numeric string, 1-10 digits.
+- `squadNumber`: integer 1-99.
+- `name`: optional or required depending final UX, max 120 chars.
+- `email`: recommended required for all registrations, valid email, max 254 chars.
+- `phone`: optional, max 40 chars, safe character allowlist.
+- `hasSsiAccount`: enum `yes | no | unsure`.
+- `ssiEmail`: required when `hasSsiAccount=yes`, valid email, max 254 chars.
+- captcha fields remain as today.
+
+Response examples:
+
+```json
+{
+  "success": true,
+  "registrationStatus": "confirmed",
+  "syncStatus": "synced",
+  "message": "Ilmoittautuminen onnistui ja SSI-squadiin asettelu onnistui."
+}
+```
+
+```json
+{
+  "success": true,
+  "registrationStatus": "confirmed",
+  "syncStatus": "manual_needed",
+  "message": "Ilmoittautuminen vastaanotettu. Järjestäjä käsittelee SSI-ilmoittautumisen tarvittaessa."
+}
+```
+
+The public result should always be success when the local registration is stored and capacity rules allow it, even if SSI sync fails.
+
+### 6.2 Organizer list
+
+```text
+GET /api/v1/register/admin/cups/:cupId/registrations
+```
+
+Requires management/admin authentication. Returns grouped registrations or flat list with fields safe for organizer use.
+
+### 6.3 CSV export
+
+```text
+GET /api/v1/register/admin/cups/:cupId/registrations.csv
+```
+
+Requires management/admin authentication. Exports active registrations with columns:
+
+```text
+Cup, Date, Squad, Name, Email, Phone, SSI account answer, SSI email, Local status, SSI sync status, Created at, Notes
+```
+
+### 6.4 Status update
+
+```text
+PATCH /api/v1/register/admin/registrations/:registrationId
+```
+
+Body:
+
+```json
+{
+  "status": "cancelled",
+  "selectedSquadNumber": 2,
+  "note": "User called organizer"
+}
+```
+
+### 6.5 Sync retry
+
+```text
+POST /api/v1/register/admin/registrations/:registrationId/sync
+```
+
+Requires management/admin authentication. Attempts SSI sync using the current stored data.
+
+---
+
+## 7. Service Design
+
+Recommended modules for the current product:
+
+```text
+scoring-proxy/lib/db/postgres.js
+scoring-proxy/lib/db/registration-store.js
+scoring-proxy/lib/services/registration-buffer-service.js
+scoring-proxy/lib/services/registration-sync-service.js
+scoring-proxy/routes/registration.js
+```
+
+Responsibilities:
+
+### `postgres.js`
+
+- Initialize pool when `DATABASE_URL` exists.
+- Return PostgreSQL disabled state if not configured.
+- Support `DB_SCHEMA` preview isolation if adopted.
+- Expose `query()` and `withTransaction()`.
+
+Use R80 as reference for pattern, not for platform model.
+
+### `registration-store.js`
+
+- Insert/update local registrations.
+- Enforce active uniqueness.
+- List by Cup/squad.
+- Update status.
+- Record sync attempts.
+- Use parameterized SQL only.
+
+### `registration-buffer-service.js`
+
+- Validate business rules and capacity.
+- Build Cup/squad snapshots from existing SSI Cup detail query.
+- Store registration before sync.
+- Decide initial sync status.
+- Return public-safe result messages.
+
+### `registration-sync-service.js`
+
+- Encapsulate existing SSI registration sequence:
+  - add to Cup,
+  - approve Cup participant,
+  - add to matches,
+  - set squad.
+- Update local sync status and attempt log.
+- Never delete or fail the local registration because of SSI failure.
+
+### `routes/registration.js`
+
+Keep route thin:
+
+- parse/validate input,
+- captcha/rate limit,
+- call service,
+- stream or return result.
+
+The current route is already long; implementation should avoid making it larger. If code changes are made, this feature should be a good opportunity to move business logic out of the route.
+
+---
+
+## 8. Capacity Rules
+
+Capacity must be calculated from active local registrations.
+
+Recommended active statuses:
+
+```text
+confirmed
+manual_handled
+```
+
+Optional active depending organizer choice:
+
+```text
+waitlisted
+```
+
+For Cup total:
+
+```sql
+SELECT COUNT(*)
+FROM public_registrations
+WHERE ssi_cup_id = $1
+  AND status IN ('confirmed', 'manual_handled')
+```
+
+For squad:
+
+```sql
+SELECT COUNT(*)
+FROM public_registrations
+WHERE ssi_cup_id = $1
+  AND selected_squad_number = $2
+  AND status IN ('confirmed', 'manual_handled')
+```
+
+SSI data can still be queried to show sync health and to bootstrap Cup/squad metadata, but it must not be the only attendance count.
+
+---
+
+## 9. UI Design
+
+Public form changes:
+
+1. Captcha remains first.
+2. Cup selection remains.
+3. Squad selection remains.
+4. Contact step changes from "SSI email" to "Yhteystiedot ja SSI-tunnus".
+
+Suggested fields:
+
+```text
+Nimi
+Sähköposti
+Puhelin (vapaaehtoinen)
+Onko sinulla Shoot'n Score It -tunnus?
+  Kyllä
+  Ei
+  En tiedä
+SSI-sähköposti, jos eri kuin yllä
+```
+
+Confirmation messages:
+
+### Synced to SSI
+
+```text
+Ilmoittautuminen onnistui.
+Sinut on lisätty myös Shoot'n Score It -kilpailuihin ja valittuun squadiin.
+```
+
+### Local-only / no SSI account
+
+```text
+Ilmoittautuminen vastaanotettu.
+Järjestäjä näkee ilmoittautumisesi osallistujalistalla. Sinua ei ole vielä lisätty Shoot'n Score It -järjestelmään.
+```
+
+### Pending/manual
+
+```text
+Ilmoittautuminen vastaanotettu.
+SSI-käsittely vaatii järjestäjän tarkistuksen.
+```
+
+Organizer view should show:
+
+```text
+Cup total: 23 / 25
+SSI synced: 19
+Local only/manual: 3
+Failed/pending sync: 1
+```
+
+Grouped by squad:
+
+```text
+Squad 1 / Laina-ase
+- Name, email, phone, sync status, local status
+
+Squad 2 / Oma ase
+...
+```
+
+---
+
+## 10. SSI Sync State Machine
+
+```text
+local registration created
+  -> hasSsiAccount=no/unsure
+       -> sync_status = manual_needed or not_applicable
+  -> hasSsiAccount=yes
+       -> pending
+       -> syncing
+       -> synced | partial | failed | manual_needed
+```
+
+Important rule:
+
+> SSI sync may update `sync_status`, but must not roll back the local registration.
+
+Known failure mapping:
+
+| SSI condition | Local result |
+|---------------|--------------|
+| User not found | `manual_needed`; public success with organizer-handled message. |
+| Cup add succeeds, match squad fails | `partial`; organizer can retry. |
+| Admin SSI session unavailable | `failed` or `pending`; organizer retry later. |
+| Capacity conflict detected locally | Public failure before local insert. |
+| Duplicate active local registration | Treat as update/re-registration. |
+
+---
+
+## 11. Scheduling Strategy
+
+MVP recommendation:
+
+- Store first.
+- Attempt SSI sync during submit for `hasSsiAccount=yes`.
+- Provide manual retry in organizer UI.
+
+Later enhancement:
+
+- Add scheduled sync job every hour.
+- Process `pending` and retryable `failed` registrations.
+- Use row-level locking with `FOR UPDATE SKIP LOCKED` if concurrent workers are possible.
+
+Candidate SQL pattern:
+
+```sql
+SELECT *
+FROM public_registrations
+WHERE sync_status IN ('pending', 'failed')
+  AND status IN ('confirmed', 'manual_handled')
+ORDER BY created_at
+FOR UPDATE SKIP LOCKED
+LIMIT 25;
+```
+
+---
+
+## 12. Deployment Notes
+
+- Use PostgreSQL for durable registration data.
+- Use Redis only for sessions/captcha/cache.
+- Keep all data stores in Europe.
+- If Render preview environments share a PostgreSQL database, adopt schema isolation with `DB_SCHEMA=pr_{number}` or equivalent.
+- Production can use `public` schema or a product-specific schema.
+
+Because this PR is design-only, it intentionally does not add Render database configuration or package dependencies.
+
+---
+
+## 13. Test Strategy
+
+Backend route tests:
+
+- submit with SSI account and successful sync,
+- submit without SSI account succeeds locally,
+- submit with SSI email not found succeeds locally with `manual_needed`,
+- duplicate submit updates existing active registration,
+- full squad is rejected,
+- invalid field values rejected,
+- admin endpoints require auth.
+
+Store tests:
+
+- insert registration,
+- update/re-register,
+- capacity count by Cup and squad,
+- status transitions,
+- sync attempt logging,
+- idempotent migration/init.
+
+UI tests:
+
+- no-SSI path,
+- yes-SSI path,
+- unsure path,
+- preselected Cup/squad URL parameters,
+- confirmation variants.
+
+---
+
+## 14. Migration / Rollout Plan
+
+1. Deploy schema and store code behind feature availability checks.
+2. Keep existing SSI-only flow functional until buffer flow is ready.
+3. Enable buffer writes for new registrations.
+4. Change public UI copy to explain local registration.
+5. Add organizer list and CSV export before relying on buffer for live events.
+6. Enable manual retry.
+7. Add scheduled sync only after manual retry proves the state model.
+
+Rollback principle:
+
+- If SSI sync code has issues, local registrations still remain in PostgreSQL.
+- Organizer CSV/export is the operational fallback.
+
+---
+
+## 15. Open Questions
+
+1. Should all users be required to provide email even without SSI account?
+2. Is phone required for non-SSI participants?
+3. Should `waitlisted` count against squad capacity?
+4. Should cancellation be public self-service via tokenized link, or organizer-only in MVP?
+5. Should the organizer UI live under `#/manage` or a new `#/registrations` route?
+6. Which Render PostgreSQL instance/schema should this product variant use?
+7. Should the confirmation email include a recommendation to create an SSI account, or avoid that to reduce friction?
+
+---
+
+## 16. Design Decision Summary
+
+| Decision | Selected direction |
+|----------|--------------------|
+| Source of truth | Local PostgreSQL registration buffer. |
+| SSI role | Best-effort synchronization target. |
+| Non-SSI participants | Accepted locally and visible to organizer. |
+| Capacity | Local active registrations. |
+| Organizer fallback | Authenticated list + CSV export. |
+| Scheduling | Design for hourly sync; MVP can start with submit-time sync + manual retry. |
+| R80 reuse | PostgreSQL infrastructure pattern only, no platform model merge. |

--- a/docs/requirements/release-8.1-registration-buffer.md
+++ b/docs/requirements/release-8.1-registration-buffer.md
@@ -1,0 +1,145 @@
+# Release 8.1 — Public Registration Buffer
+
+**Created:** 2026-05-23  
+**Status:** 📋 Specified  
+**Scope:** Requirements and design only. No runtime code changes in this PR.  
+**Product variant:** Current `main`-based TurRes SSI tools product. Do not mix with the separate R80 platform product branch.
+
+---
+
+## Background
+
+The current public registration flow (`#/register`) assumes that the shooter already has a Shoot'n Score It (SSI) account. The backend immediately attempts to add the shooter to the Cup and to the component matches, then assigns the selected squad. If SSI cannot find the email address, the flow fails and asks the shooter to register with SSI first.
+
+This is not enough for Kupittaa Cup operating practice. Some shooters do not have an SSI account, but they still need to be accepted into the real event participant list and assigned to the correct day/squad group. Therefore the application needs an own persistent registration buffer. SSI becomes a synchronization target, not the source of truth for total attendance.
+
+---
+
+## Product Boundary
+
+This release is for the existing `main` product variant:
+
+- public Kupittaa Cup registration (`#/register`)
+- SSI-backed squadding automation
+- Render-hosted TurRes SSI tools
+
+The R80 branch contains a different platform product variant with PostgreSQL usage patterns. R80 may be used as a reference for PostgreSQL connection, schema initialization, and testing style, but R8.1 must not copy unrelated platform product concepts into the current product unless explicitly approved.
+
+---
+
+## Goals
+
+1. Make the application's own database the authoritative list of all public registrations.
+2. Allow registration even when the shooter does not have an SSI account.
+3. Preserve the existing successful SSI automation for shooters who can be found in SSI.
+4. Track SSI synchronization state separately from registration acceptance.
+5. Show organizers the true participant count per Cup and per squad.
+6. Keep the public registration flow simple and Finnish-language first.
+7. Keep SSI internals hidden from public users.
+
+---
+
+## Non-Goals
+
+The first implementation of this release must not attempt to solve all surrounding platform needs:
+
+- No merge from R80 platform branch.
+- No tenant/account platform model unless separately approved.
+- No replacement of existing scoring or management features.
+- No hard dependency on creating SSI user accounts automatically.
+- No browser automation from the end user's browser.
+- No iframe embedding of SSI.
+- No exposure of SSI participant IDs, match IDs, squad IDs, or admin details in public API responses.
+
+---
+
+## Requirements
+
+### R81 Functional Requirements
+
+| # | Requirement | Priority | Status |
+|---|-------------|----------|--------|
+| R81-REG1 | **Persistent Registration Buffer**: Every public registration submission must be stored first in PostgreSQL before any SSI synchronization attempt. | HIGH | 📋 Specified |
+| R81-REG2 | **SSI Account Optional**: The public form must allow the shooter to indicate whether they have an SSI account, do not have one, or are unsure. SSI email remains optional for non-SSI registrations. | HIGH | 📋 Specified |
+| R81-REG3 | **Authoritative Attendance Count**: Cup and squad capacity checks must count active buffered registrations, not only SSI competitors. SSI data may be shown as synchronization state, but not used as the sole source of attendance. | HIGH | 📋 Specified |
+| R81-REG4 | **Squad Selection Stored Locally**: Selected squad must be persisted in the buffer even when SSI synchronization is not possible. | HIGH | 📋 Specified |
+| R81-REG5 | **Best-Effort SSI Sync**: If the shooter provides an SSI email and can be found in SSI, the backend should attempt the existing Cup + component match registration and squad assignment flow. | HIGH | 📋 Specified |
+| R81-REG6 | **Non-SSI Success Result**: If the shooter has no SSI account or cannot be found in SSI, the public registration must still succeed locally and show a clear confirmation that the organizer has received the registration. | HIGH | 📋 Specified |
+| R81-REG7 | **Re-registration / Update**: A returning shooter must be able to update their squad or SSI-account answer without creating duplicate active registrations for the same Cup and email/identity. | MEDIUM | 📋 Specified |
+| R81-REG8 | **Organizer View**: Organizers must be able to view all active buffered registrations grouped by Cup and squad, including SSI sync status. | HIGH | 📋 Specified |
+| R81-REG9 | **CSV Export**: Organizers must be able to export the full buffered participant list for range-day fallback use. | HIGH | 📋 Specified |
+| R81-REG10 | **Manual Status Changes**: Organizers must be able to mark a registration cancelled, confirmed, waitlisted, or manually handled. | MEDIUM | 📋 Specified |
+| R81-REG11 | **Manual Sync Retry**: Organizers must be able to retry SSI synchronization for failed or pending registrations. | MEDIUM | 📋 Specified |
+| R81-REG12 | **Scheduled Sync Candidate Model**: The design must support hourly or otherwise scheduled SSI synchronization, but the MVP may start with synchronous submit-time sync plus manual retry. | MEDIUM | 📋 Specified |
+| R81-REG13 | **Confirmation Email**: Confirmation email must reflect whether the registration is fully synchronized to SSI, locally registered only, or pending sync. Email failure must not fail the registration. | MEDIUM | 📋 Specified |
+| R81-REG14 | **WordPress/Tapahtumakalenteri Entry Point**: Event pages should link to the registration tool with optional Cup/date/squad URL parameters. The app must support preselection when parameters are present. | LOW | 📋 Specified |
+
+### R81 Data Requirements
+
+| # | Requirement | Priority | Status |
+|---|-------------|----------|--------|
+| R81-DATA1 | **PostgreSQL Storage**: Registration buffer data must be stored in PostgreSQL, not Redis. Redis remains suitable for sessions/cache only. | HIGH | 📋 Specified |
+| R81-DATA2 | **EU Hosting**: Database and any additional storage used by this release must remain in Europe, consistent with project deployment constraints. | HIGH | 📋 Specified |
+| R81-DATA3 | **Schema Isolation Compatibility**: Design should be compatible with PR preview schema isolation using a `DB_SCHEMA`-style approach if preview environments share a database. | MEDIUM | 📋 Specified |
+| R81-DATA4 | **Idempotency**: Repeated submit or retry operations must not create duplicate active registrations or duplicate SSI side effects where preventable. | HIGH | 📋 Specified |
+| R81-DATA5 | **Audit Trail**: Store registration lifecycle events and SSI sync attempts for troubleshooting and accountability. | MEDIUM | 📋 Specified |
+| R81-DATA6 | **Minimal PII**: Store only data needed to operate the event: name, email, phone if required, SSI-account answer, selected Cup/squad, status, and sync state. | HIGH | 📋 Specified |
+
+### R81 Security Requirements
+
+| # | Requirement | Priority | Status |
+|---|-------------|----------|--------|
+| R81-SEC1 | **No Public Participant Listing**: Public endpoints must not expose registration lists, names, emails, or counts that enable participant enumeration beyond existing aggregate capacity indicators. | HIGH | 📋 Specified |
+| R81-SEC2 | **Rate Limiting**: Existing public registration rate limiting and captcha protections must continue to apply to buffered submissions. | HIGH | 📋 Specified |
+| R81-SEC3 | **Input Validation**: Public inputs must remain strictly validated. New optional fields must have explicit max lengths and allowed values. | HIGH | 📋 Specified |
+| R81-SEC4 | **Organizer Authentication**: Organizer list, CSV export, status changes, and sync retry endpoints must require authenticated management access. | HIGH | 📋 Specified |
+| R81-SEC5 | **Sanitized Errors**: SSI errors and database errors must be logged server-side but shown to public users only as generic, user-safe Finnish messages. | HIGH | 📋 Specified |
+| R81-SEC6 | **Privacy-Aware Logs**: Logs must avoid unnecessary PII. Email may be masked in operational logs unless needed for admin troubleshooting. | MEDIUM | 📋 Specified |
+
+### R81 Testing Requirements
+
+| # | Requirement | Priority | Status |
+|---|-------------|----------|--------|
+| R81-TEST1 | **Route Tests**: Add HTTP contract tests for buffered submit, validation errors, duplicate/update behavior, user-not-found fallback, and organizer endpoints. | HIGH | 📋 Specified |
+| R81-TEST2 | **Store Tests**: Add unit tests for registration store functions, including idempotency and status transitions. | HIGH | 📋 Specified |
+| R81-TEST3 | **SSI Sync Tests**: Add tests proving that local registration remains successful when SSI sync fails or user is not found. | HIGH | 📋 Specified |
+| R81-TEST4 | **UI Tests**: Add tests for the public form states: has SSI account, no SSI account, unsure, success locally only, and success synchronized. | MEDIUM | 📋 Specified |
+| R81-TEST5 | **Migration Tests**: If schema initialization/migrations are added, test that they are idempotent and safe to run repeatedly. | MEDIUM | 📋 Specified |
+
+---
+
+## Suggested Implementation Phases
+
+| Phase | Requirements | Outcome |
+|-------|--------------|---------|
+| Phase 0 | This PR | Requirements and design only. No runtime behavior change. |
+| Phase 1 | R81-DATA1, R81-REG1, R81-REG4, R81-TEST2 | PostgreSQL-backed buffer store and tests. |
+| Phase 2 | R81-REG2, R81-REG6, R81-SEC2, R81-SEC3, R81-TEST1, R81-TEST4 | Public form supports non-SSI registrations. |
+| Phase 3 | R81-REG3, R81-REG8, R81-REG9, R81-SEC4 | Organizer view and CSV export. |
+| Phase 4 | R81-REG5, R81-REG11, R81-REG12, R81-TEST3 | SSI sync state machine and retry handling. |
+| Phase 5 | R81-REG7, R81-REG13, R81-REG14 | Re-registration polish, emails, URL preselection. |
+
+---
+
+## Open Decisions
+
+| Decision | Options | Recommendation |
+|----------|---------|----------------|
+| Public identity key | Email only; email + phone; generated token | Use normalized email when provided; for no-email flow require at least email or phone before implementation. |
+| Scheduled sync mechanism | Render cron; internal timer; manual only | Start with submit-time sync + manual retry, then add Render cron or scheduled job if operationally needed. |
+| Admin UI location | Extend `#/manage`; add `#/registrations`; add separate report page | Prefer a separate management sub-view so public registration buffer stays conceptually distinct from SSI match management. |
+| Non-SSI match-day handling | CSV only; manual SSI creation; later self-service SSI account creation | MVP: CSV + organizer status. Later: support manual mapping to SSI participant if created. |
+| PostgreSQL layer source | Reuse R80 pattern; add minimal product-specific store | Reuse architectural pattern only; do not merge R80 platform domain model. |
+
+---
+
+## Acceptance Criteria for the First Code PR
+
+The first code PR after this design is acceptable when:
+
+1. Registration data is persisted in PostgreSQL before SSI sync is attempted.
+2. A registration can succeed locally even if SSI lookup fails.
+3. Existing successful SSI-account flow still works.
+4. Capacity calculations use local active registrations.
+5. Unit and route tests cover success, duplicate/update, validation, and SSI-failure cases.
+6. No R80 platform product code is merged into `main` except explicitly selected PostgreSQL infrastructure patterns.


### PR DESCRIPTION
## Summary

This PR adds requirements and design documentation for Release 8.1 — Public Registration Buffer.

No runtime code is changed in this PR.

## What changed

- Added `docs/requirements/release-8.1-registration-buffer.md`
  - Defines R81 functional, data, security, and testing requirements.
  - Captures the product boundary: this is for the current `main` TurRes SSI tools product, not the separate R80 platform product.
  - Specifies PostgreSQL as durable storage for the registration buffer.
- Added `docs/design/registration-buffer-design.md`
  - Describes current vs target registration flow.
  - Defines proposed PostgreSQL tables for local registrations and sync attempts.
  - Defines API, service, capacity, UI, SSI sync, deployment, and test design.
  - Notes that R80 can be used as PostgreSQL infrastructure reference only, without merging platform concepts.

## Scope boundaries

- Does not modify application runtime behavior.
- Does not add package dependencies.
- Does not modify Render configuration.
- Does not modify `main` directly.
- Does not merge or alter R80 branches.

## Testing

Documentation-only PR. No automated tests run.

## Review focus

Please review especially:

1. Whether R81 is the right release/requirement identifier.
2. Whether email should be required for all registrations, including non-SSI participants.
3. Whether organizer UI should live under `#/manage` or a new `#/registrations` route.
4. Whether the proposed PostgreSQL schema and sync status model match the operating need.