### PR TITLE
R100: Add docs PR policy and gate

### DIFF
--- a/.github/workflows/docs-pr-gate.yml
+++ b/.github/workflows/docs-pr-gate.yml
@@ -1,0 +1,75 @@
+name: Docs PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  docs-only:
+    name: Verify docs-only PR
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files
+        id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+
+          echo "Changed files:"
+          cat changed-files.txt
+
+          if [ ! -s changed-files.txt ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "No changed files found."
+            exit 0
+          fi
+
+          non_docs=$(grep -Ev '^(docs/|\.github/ISSUE_TEMPLATE/|\.github/PULL_REQUEST_TEMPLATE|README\.md$|AGENTS\.md$|.*\.md$)' changed-files.txt || true)
+
+          if [ -n "$non_docs" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "Non-doc files changed:"
+            echo "$non_docs"
+            exit 1
+          fi
+
+          echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          echo "This PR only changes documentation files."
+
+  enable-merge-queue:
+    name: Enable merge queue for labeled docs PR
+    needs: docs-only
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.draft == false &&
+      needs.docs-only.outputs.docs_only == 'true' &&
+      contains(github.event.pull_request.labels.*.name, 'auto-merge-docs')
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Enable GitHub auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr merge "$PR_URL" --auto --squash

--- a/docs/design/docs-pr-policy.md
+++ b/docs/design/docs-pr-policy.md
@@ -1,0 +1,52 @@
+# Docs PR Policy
+
+This repository supports a lightweight automation path for documentation-only pull requests.
+
+## Goal
+
+Allow low-risk documentation changes to move faster while keeping runtime code changes under normal manual review.
+
+## Label
+
+Use this label on a pull request when it is safe for GitHub to enable auto-merge after required checks pass:
+
+```text
+auto-merge-docs
+```
+
+## What counts as docs-only
+
+The workflow accepts changes only under these paths/patterns:
+
+```text
+docs/**
+.github/ISSUE_TEMPLATE/**
+.github/PULL_REQUEST_TEMPLATE
+README.md
+AGENTS.md
+*.md
+```
+
+If any runtime, workflow, package, deployment, UI, backend, or test file changes, the docs-only gate fails and the PR must follow normal manual review.
+
+## Required GitHub repository setting
+
+GitHub auto-merge must be enabled in repository settings:
+
+```text
+Settings -> General -> Pull Requests -> Allow auto-merge
+```
+
+Branch protection should still require normal status checks. For runtime code PRs, keep manual approval required.
+
+## Recommended operating model
+
+| PR type | Suggested flow |
+|---|---|
+| Documentation-only | Add `auto-merge-docs` label after quick review. GitHub merges when checks pass. |
+| Runtime code | Require manual review and approval. Auto-merge can be enabled only after approval if desired. |
+| Security-sensitive docs | Treat as runtime code and review manually. |
+
+## Notes
+
+This policy does not bypass branch protection. It only asks GitHub to enable auto-merge for labeled documentation-only PRs. If required checks or approvals are configured, GitHub still enforces them.


### PR DESCRIPTION
## Summary

Adds a small documentation-only PR policy and workflow gate.

## What changed

- Added `.github/workflows/docs-pr-gate.yml`
  - Checks whether a PR only changes documentation files.
  - If the PR is docs-only and has the `auto-merge-docs` label, it enables GitHub auto-merge with squash merge.
  - Does not bypass branch protection; required checks and required approvals still apply.
- Added `docs/design/docs-pr-policy.md`
  - Documents the label, allowed docs-only paths, and required GitHub repository setting.

## Runtime impact

None. This only adds a GitHub Actions workflow and documentation.

## Required repo setting

GitHub auto-merge must be enabled manually:

`Settings -> General -> Pull Requests -> Allow auto-merge`

## Safety boundaries

Runtime code PRs are not auto-merged by this workflow. Any changed file outside the allowed documentation paths makes the docs-only gate fail.