### PR TITLE
R100: Run CI for release branch pull requests

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,11 +1,15 @@
 name: CI / Deploy
 
-# GitHub Flow: Runs tests on all PRs, deploys only from main
+# GitHub Flow:
+# - Runs tests on PRs targeting main and release branches.
+# - Deploys only from pushes to main.
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
 
 jobs:
   test-audit-build:


### PR DESCRIPTION
## Summary

Updates the CI / Deploy workflow so test/audit/build runs for pull requests targeting release branches as well as `main`.

## What changed

- `pull_request.branches` now includes:
  - `main`
  - `release/**`

## Release branch model

This PR now targets `release/r100-registration-buffer` because R100 feature work is being accumulated in the release branch first. The workflow change should therefore be part of the R100 release branch before the release is eventually merged to `main`.

## Safety

- Push trigger remains limited to `main`.
- Deploy job condition remains unchanged:
  - deploy only runs for `push` to `refs/heads/main`.
- This enables CI for the R100 release branch PR model without deploying from release branches.

## Why

PR #163 targets `release/r100-registration-buffer`, but no CI checks were running because the workflow only listened for PRs targeting `main`.

## Testing

Workflow-only change. Expected validation is that future PRs targeting `release/**` receive the same test/audit/build checks as `main` PRs once this workflow change is present in the release branch.